### PR TITLE
feat(Pom-Jacoco): Updated from 0.8.11 > 0.8.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Version 8.11 caused large stacktrace of incompatible classes due to version issues. going to 8.12 seems to have resolved it as of now.