### PR TITLE
build(Pom-ArgLine) - Added inline-Mockito explicitly as a javaagent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
-                   <!-- This arg line removes warnings regarding dynamic loading.
-                   But if its kept then it hinders jacoco from generating an exec.
-                   <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading</argLine>
-                   -->
+                    <!-- TODO If compile/test errors occur, comment away these arg-lines -->
+                    <argLine>
+                        -javaagent:${settings.localRepository}/org/mockito/mockito-core/5.15.2/mockito-core-5.15.2.jar
+                        -XX:+EnableDynamicAgentLoading
+                        -Djdk.instrument.traceUsage=false
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Added 3 arglines to remove warnings and future-poof inline mockito

Should remove the warnings that's revolving the future updates and potential incompatability with self-attaching mockito.